### PR TITLE
Add support for MP3 lyrics tag - USLT

### DIFF
--- a/src/ddf/minim/AudioMetaData.java
+++ b/src/ddf/minim/AudioMetaData.java
@@ -194,6 +194,18 @@ public abstract class AudioMetaData
 	}
 	
 	/**
+	 * The lyrics for the recording, if any.
+	 * 
+	 * @return String: the lyrics tag
+	 * 
+	 * @related AudioMetaData
+	 */
+	public String lyrics()
+	{
+		return "";
+	}
+    
+	/**
 	 * The orchestra that performed the recording.
 	 * 
 	 * @return String: the orchestra tag

--- a/src/ddf/minim/javasound/MP3MetaData.java
+++ b/src/ddf/minim/javasound/MP3MetaData.java
@@ -89,6 +89,11 @@ class MP3MetaData extends BasicMetaData
 		return getTag("mp3.id3tag.composer");
 	}
 	
+	public String lyrics()
+	{
+		return getTag("mp3.id3tag.lyrics");
+	}
+	
 	public String orchestra()
 	{
 		return getTag("mp3.id3tag.orchestra");

--- a/src/ddf/minim/javasound/MpegAudioFileReader.java
+++ b/src/ddf/minim/javasound/MpegAudioFileReader.java
@@ -187,6 +187,7 @@ class MpegAudioFileReader extends TAudioFileReader
 		codeToPropName.put("TPUB", "mp3.id3tag.publisher");
 		codeToPropName.put("TPE2", "mp3.id3tag.orchestra");
 		codeToPropName.put("TLEN", "mp3.id3tag.length");
+		codeToPropName.put("USLT", "mp3.id3tag.lyrics");
 	}
 
 	/**
@@ -732,7 +733,7 @@ class MpegAudioFileReader extends TAudioFileReader
 						system.error("Don't know the ID3 code " + code);
 						continue;
 					}
-					if ( code.equals("COMM") )
+					if ( code.equals("COMM") || code.equals("USLT") )
 					{
 						value = parseText(bframes, i, size, 5);
 					}


### PR DESCRIPTION
Hello, this is a pretty simple change to add support for MP3 files with embedded lyrics.  The USLT tag is for unsynchronized lyrics, of the same format internally as comments, and it works ok with the MP3s I have with lyrics.  Also considered the SYLT tag, for synchronized lyrics, and has slightly more involved format.  Since I didn't have any MP3s with that tag, I did not add it.