### PR TITLE
Remove mention that Mac only listens to Mic-In

### DIFF
--- a/src/ddf/minim/AudioInput.java
+++ b/src/ddf/minim/AudioInput.java
@@ -25,10 +25,7 @@ import ddf.minim.spi.AudioStream;
  * An AudioInput is a connection to the current record source of the computer. 
  * How the record source for a computer is set will depend on the soundcard and OS, 
  * but typically a user can open a control panel and set the source from there. 
- * Unfortunately, there is no way to set the record source from Java. 
- * This is particularly problematic on the Mac because the input will always wind 
- * up being connected to the Mic-In, even if the user has set the input differently 
- * using their audio control panel. 
+ * Unfortunately, there is no way to set the record source from Java.
  * <p>
  * You can obtain an AudioInput from Minim by using one of the getLineIn methods:
  * <pre>


### PR DESCRIPTION
I have confirmed that getLineIn() will obtain the device selected in System Preferences, not just the default system input.  I tested using Loopback to create a virtual audio cable that routes the audio from applications into a usable microphone input for recording, streaming, etc. and was curious if it would obtain that input, or the microphone built into my laptop.  I'm glad to say, it turns out that it was the system audio mic that I selected!

<img width="1920" alt="screen shot 2017-05-20 at 14 20 38" src="https://cloud.githubusercontent.com/assets/5179191/26279454/6e6e0124-3d69-11e7-98ce-a672ab0d9b39.png">