### PR TITLE
Removed javadoc plugin as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,11 @@
 			<artifactId>maven-javadoc-plugin</artifactId>
 			<version>2.10.4</version>
 		</dependency> -->
-		<dependency>
+		<!-- <dependency>
 			<groupId>com.googlecode.soundlibs</groupId>
 			<artifactId>tritonus-share</artifactId>
 			<version>0.3.7-2</version>
-		</dependency>
+		</dependency> -->
 		<dependency>
 			<groupId>com.googlecode.soundlibs</groupId>
 			<artifactId>mp3spi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,11 @@
 	</distributionManagement>
 
 	<dependencies>
-		<dependency>
+		<!-- <dependency>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-javadoc-plugin</artifactId>
 			<version>2.10.4</version>
-		</dependency>
+		</dependency> -->
 		<dependency>
 			<groupId>com.googlecode.soundlibs</groupId>
 			<artifactId>tritonus-share</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,11 @@
 			<artifactId>mp3spi</artifactId>
 			<version>1.9.5.4</version>
 		</dependency>
-		<dependency>
+		<!-- <dependency>
 			<groupId>javazoom</groupId>
 			<artifactId>jlayer</artifactId>
 			<version>1.0.1</version>
-		</dependency>
+		</dependency> -->
 	</dependencies>
 
 


### PR DESCRIPTION
There's no point in having the javadoc plugin as a dependency even when it is used as a plugin.

On top of that it adds more dependencies to the hierarchy.